### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -20,5 +20,9 @@ handleRequest(HttpRequest request) async {
   // Serve the file
   var transformer =
       new RangeHeaderTransformer(header, 'video/mp4', await file.length());
-  await file.openRead().transform(transformer).pipe(request.response);
+  await file
+      .openRead()
+      .cast<List<int>>()
+      .transform(transformer)
+      .pipe(request.response);
 }


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900